### PR TITLE
DB制約変更に伴う修正

### DIFF
--- a/src/main/java/football/StatsManagement/model/data/GameResult.java
+++ b/src/main/java/football/StatsManagement/model/data/GameResult.java
@@ -16,7 +16,7 @@ public class GameResult {
   private int awayClubId;
   private int homeScore;
   private int awayScore;
-  private int winnerClubId; // 0 if draw
+  private Integer winnerClubId; // null if draw、外部キー制約のため0→nullに変更
   private int leagueId;
   private LocalDate gameDate;
   private int seasonId;
@@ -33,7 +33,7 @@ public class GameResult {
     } else if (homeScore < awayScore) {
       this.winnerClubId = awayClubId;
     } else {
-      this.winnerClubId = 0;
+      this.winnerClubId = null;
     }
     this.leagueId = gameResultForJson.getLeagueId();
     this.gameDate = gameResultForJson.getGameDate();

--- a/src/main/java/football/StatsManagement/model/domain/ClubForStanding.java
+++ b/src/main/java/football/StatsManagement/model/domain/ClubForStanding.java
@@ -58,6 +58,9 @@ public class ClubForStanding {
   private static int getWins(List<GameResult> gameResults, int clubId) {
     int wins = 0;
     for (GameResult gameResult : gameResults) {
+      if (gameResult.getWinnerClubId() == null) {
+        continue;
+      }
       wins += gameResult.getWinnerClubId() == clubId ? 1 : 0;
     }
     return wins;
@@ -66,7 +69,7 @@ public class ClubForStanding {
   private static int getDraws(List<GameResult> gameResults) {
     int draws = 0;
     for (GameResult gameResult : gameResults) {
-      draws += gameResult.getWinnerClubId() == 0 ? 1 : 0;
+      draws += gameResult.getWinnerClubId() == null ? 1 : 0;
     }
     return draws;
   }
@@ -96,10 +99,10 @@ public class ClubForStanding {
         .toList();
     int pointsAgainst = 0;
     for (GameResult gameResult : gameResults) {
-      if (gameResult.getWinnerClubId() == this.getClub().getId()) {
-        pointsAgainst += 3;
-      } else if (gameResult.getWinnerClubId() == 0) {
+      if (gameResult.getWinnerClubId() == null) {
         pointsAgainst += 1;
+      } else if (gameResult.getWinnerClubId() == this.getClub().getId()) {
+        pointsAgainst += 3;
       }
     }
     return pointsAgainst;

--- a/src/test/java/football/StatsManagement/model/domain/ClubForStandingTest.java
+++ b/src/test/java/football/StatsManagement/model/domain/ClubForStandingTest.java
@@ -27,11 +27,11 @@ class ClubForStandingTest {
     int seasonId = 1;
     Club club = new Club(1, 1, "Sample Club");
     List<GameResult> gameResults = List.of(
-        new GameResult(1, 1, 2, 1, 1, 0, 1, LocalDate.now(), 1),
-        new GameResult(2, 2, 1, 1, 0, 2, 1, LocalDate.now(), 1),
-        new GameResult(3, 1, 3, 2, 0, 1, 1, LocalDate.now(), 1),
-        new GameResult(4, 1, 2, 2, 0, 1, 1, LocalDate.now(), 1),
-        new GameResult(5, 2, 1, 1, 3, 1, 1, LocalDate.now(), 1)
+        new GameResult(1, 1, 2, 1, 1, null, 1, LocalDate.now(), 1),
+        new GameResult(2, 2, 1, 1, 0, 2   , 1, LocalDate.now(), 1),
+        new GameResult(3, 1, 3, 2, 0, 1   , 1, LocalDate.now(), 1),
+        new GameResult(4, 1, 2, 2, 0, 1   , 1, LocalDate.now(), 1),
+        new GameResult(5, 2, 1, 1, 3, 1   , 1, LocalDate.now(), 1)
     );
     when(service.getGameResultsByClubAndSeason(seasonId, club.getId())).thenReturn(gameResults);
     // Act
@@ -47,11 +47,11 @@ class ClubForStandingTest {
     // Arrange
     Club club = new Club(1, 1, "Sample Club");
     List<GameResult> gameResults = List.of(
-        new GameResult(1, 1, 2, 1, 1, 0, 1, LocalDate.now(), 1),
-        new GameResult(2, 2, 1, 1, 0, 2, 1, LocalDate.now(), 1),
-        new GameResult(3, 1, 3, 2, 0, 1, 1, LocalDate.now(), 1),
-        new GameResult(4, 1, 2, 2, 0, 1, 1, LocalDate.now(), 1),
-        new GameResult(5, 2, 1, 1, 3, 1, 1, LocalDate.now(), 1)
+        new GameResult(1, 1, 2, 1, 1, null, 1, LocalDate.now(), 1),
+        new GameResult(2, 2, 1, 1, 0, 2   , 1, LocalDate.now(), 1),
+        new GameResult(3, 1, 3, 2, 0, 1   , 1, LocalDate.now(), 1),
+        new GameResult(4, 1, 2, 2, 0, 1   , 1, LocalDate.now(), 1),
+        new GameResult(5, 2, 1, 1, 3, 1   , 1, LocalDate.now(), 1)
     );
     ClubForStanding clubForStanding = new ClubForStanding(gameResults, club, 5, 3, 1, 1, 10, 8, 3, 5);
     // Act

--- a/src/test/java/football/StatsManagement/repository/FootballRepositoryTest.java
+++ b/src/test/java/football/StatsManagement/repository/FootballRepositoryTest.java
@@ -164,8 +164,8 @@ class FootballRepositoryTest {
     int clubId = 1;
     List<GameResult> actual = sut.selectGameResultsByClubAndSeason(seasonId, clubId);
     List<GameResult> expected = List.of(
-        new GameResult(1, 1, 2, 2, 1, 1, 1, LocalDate.of(2019, 8, 1), 1),
-        new GameResult(3, 2, 1, 2, 2, 0, 1, LocalDate.of(2019, 8, 2), 1)
+        new GameResult(1, 1, 2, 2, 1, 1   , 1, LocalDate.of(2019, 8, 1), 1),
+        new GameResult(3, 2, 1, 2, 2, null, 1, LocalDate.of(2019, 8, 2), 1)
     );
     assertThat(actual.size()).isEqualTo(expected.size());
     assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
@@ -319,12 +319,12 @@ class FootballRepositoryTest {
     *
     * */
     List<GameResult> expected = List.of(
-        new GameResult(1, 1, 2, 2, 1, 1, 1, LocalDate.of(2019, 8, 1), 1),
-        new GameResult(2, 3, 4, 1, 2, 4, 2, LocalDate.of(2019, 8, 1), 1),
-        new GameResult(3, 2, 1, 2, 2, 0, 1, LocalDate.of(2019, 8, 2), 1),
-        new GameResult(4, 1, 2, 1, 2, 2, 1, LocalDate.of(2020, 8, 3), 2),
-        new GameResult(5, 3, 4, 2, 1, 3, 2, LocalDate.of(2020, 8, 3), 2),
-        new GameResult(6, 3, 4, 1, 1, 0, 2, LocalDate.of(2020, 8, 4), 2)
+        new GameResult(1, 1, 2, 2, 1, 1   , 1, LocalDate.of(2019, 8, 1), 1),
+        new GameResult(2, 3, 4, 1, 2, 4,    2, LocalDate.of(2019, 8, 1), 1),
+        new GameResult(3, 2, 1, 2, 2, null, 1, LocalDate.of(2019, 8, 2), 1),
+        new GameResult(4, 1, 2, 1, 2, 2   , 1, LocalDate.of(2020, 8, 3), 2),
+        new GameResult(5, 3, 4, 2, 1, 3   , 2, LocalDate.of(2020, 8, 3), 2),
+        new GameResult(6, 3, 4, 1, 1, null, 2, LocalDate.of(2020, 8, 4), 2)
     );
     assertThat(actual.size()).isEqualTo(expected.size());
     assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -41,12 +41,12 @@ INSERT INTO seasons (id, name, start_date, end_date, current) VALUES
   (2, '2020-21', '2020-07-01', '2021-06-30', 1);
 
 INSERT INTO game_results (home_club_id, away_club_id, home_score, away_score, winner_club_id, league_id, game_date, season_id) VALUES
-  (1, 2, 2, 1, 1, 1, '2019-08-01', 1),
-  (3, 4, 1, 2, 4, 2, '2019-08-01', 1),
-  (2, 1, 2, 2, 0, 1, '2019-08-02', 1),
-  (1, 2, 1, 2, 2, 1, '2020-08-03', 2),
-  (3, 4, 2, 1, 3, 2, '2020-08-03', 2),
-  (3, 4, 1, 1, 0, 2, '2020-08-04', 2);
+  (1, 2, 2, 1, 1   , 1, '2019-08-01', 1),
+  (3, 4, 1, 2, 4   , 2, '2019-08-01', 1),
+  (2, 1, 2, 2, null, 1, '2019-08-02', 1),
+  (1, 2, 1, 2, 2   , 1, '2020-08-03', 2),
+  (3, 4, 2, 1, 3   , 2, '2020-08-03', 2),
+  (3, 4, 1, 1, null, 2, '2020-08-04', 2);
 
 INSERT INTO player_game_stats (player_id, club_id, number, starter, goals, assists, minutes, yellow_cards, red_cards, game_id) VALUES
   (1, 1, 1, 1, 1, 0, 90, 0, 0, 1),

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,13 +1,40 @@
-CREATE TABLE `clubs` (
+CREATE TABLE `countries` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `league_id` int DEFAULT NULL,
   `name` varchar(30) DEFAULT NULL,
   PRIMARY KEY (`id`)
 );
 
-CREATE TABLE `countries` (
+CREATE TABLE `leagues` (
   `id` int NOT NULL AUTO_INCREMENT,
+  `country_id` int DEFAULT NULL,
   `name` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`country_id`) REFERENCES `countries`(`id`) ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE `clubs` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `league_id` int DEFAULT NULL,
+  `name` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`league_id`) REFERENCES `leagues`(`id`) ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE `players` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `club_id` int DEFAULT NULL,
+  `name` varchar(20) DEFAULT NULL,
+  `number` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`club_id`) REFERENCES `clubs`(`id`) ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE `seasons` (
+  `id` int NOT NULL,
+  `name` varchar(10) DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `end_date` date DEFAULT NULL,
+  `current` tinyint DEFAULT 1,
   PRIMARY KEY (`id`)
 );
 
@@ -21,14 +48,12 @@ CREATE TABLE `game_results` (
   `league_id` int DEFAULT NULL,
   `game_date` date DEFAULT NULL,
   `season_id` int DEFAULT NULL,
-  PRIMARY KEY (`id`)
-);
-
-CREATE TABLE `leagues` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `country_id` int DEFAULT NULL,
-  `name` varchar(30) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`home_club_id`) REFERENCES `clubs`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (`away_club_id`) REFERENCES `clubs`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (`winner_club_id`) REFERENCES `clubs`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (`league_id`) REFERENCES `leagues`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (`season_id`) REFERENCES `seasons`(`id`) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 CREATE TABLE `player_game_stats` (
@@ -43,23 +68,13 @@ CREATE TABLE `player_game_stats` (
   `yellow_cards` int DEFAULT NULL,
   `red_cards` int DEFAULT NULL,
   `game_id` int DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (`club_id`) REFERENCES `clubs`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  FOREIGN KEY (`game_id`) REFERENCES `game_results`(`id`) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
-CREATE TABLE `players` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `club_id` int DEFAULT NULL,
-  `name` varchar(20) DEFAULT NULL,
-  `number` int DEFAULT NULL,
-  PRIMARY KEY (`id`)
-);
 
-CREATE TABLE `seasons` (
-  `id` int NOT NULL,
-  `name` varchar(10) DEFAULT NULL,
-  `start_date` date DEFAULT NULL,
-  `end_date` date DEFAULT NULL,
-  `current` tinyint DEFAULT 1,
-  PRIMARY KEY (`id`)
-);
+
+
 


### PR DESCRIPTION
・全体的な外部キーの追加

・外部キーが要因で、draw時にwinnerClubId=0が機能しなくなる
　→winnerClubIdの方をINTEGERに変更し、draw時はnullを設定