### PR TITLE
機能追加：選手を無所属状態にする処理

### DIFF
--- a/src/main/java/football/StatsManagement/controller/FootballController.java
+++ b/src/main/java/football/StatsManagement/controller/FootballController.java
@@ -387,6 +387,7 @@ public class FootballController {
    * @param clubId クラブID
    * @return 昇格・降格されたクラブ
    */
+  @Operation(summary = "クラブの昇格・降格", description = "クラブを他のリーグに昇格・降格させます")
   @PatchMapping("club-promote-or-relegate/{clubId}")
   public ResponseEntity<Club> promoteOrRelegateClub(
       @RequestParam @Positive int leagueId,
@@ -395,6 +396,20 @@ public class FootballController {
     footballService.updateClubLeague(clubId, leagueId);
 
     return ResponseEntity.ok().body(footballService.getClub(clubId));
+  }
+
+  /**
+   * 選手の契約解除（無所属にする）
+   * @param playerId 選手ID
+   * @return 契約解除された選手
+   */
+  @Operation(summary = "選手の契約解除", description = "選手を契約解除（無所属状態に）します")
+  @PatchMapping("player-make-free/{playerId}")
+  public ResponseEntity<Player> makePlayerFree(@PathVariable @Positive int playerId)
+      throws ResourceNotFoundException, ResourceConflictException {
+    footballService.updatePlayerClubIdNull(playerId);
+
+    return ResponseEntity.ok().body(footballService.getPlayer(playerId));
   }
 
 

--- a/src/main/java/football/StatsManagement/model/entity/Country.java
+++ b/src/main/java/football/StatsManagement/model/entity/Country.java
@@ -1,7 +1,6 @@
 package football.StatsManagement.model.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,9 +11,8 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor // @Select用
 public class Country {
-  private final int id;
 
-  @NotBlank
+  private final int id;
   private String name;
 
   /**

--- a/src/main/java/football/StatsManagement/model/entity/Player.java
+++ b/src/main/java/football/StatsManagement/model/entity/Player.java
@@ -14,16 +14,9 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor // @Select用
 public class Player {
-  @Positive
   private final int id;
-
-  @Positive
-  private int clubId;
-
-  @NotBlank
+  private Integer clubId; // 無所属をnullで表現するためInteger
   private String name;
-
-  @Positive
   private int number;
 
   /**

--- a/src/main/java/football/StatsManagement/repository/FootballRepository.java
+++ b/src/main/java/football/StatsManagement/repository/FootballRepository.java
@@ -332,4 +332,11 @@ public interface FootballRepository {
    */
   @Update("UPDATE clubs SET league_id = #{leagueId} WHERE id = #{id}")
   void updateClubLeague(int id, int leagueId);
+
+  /**
+   * 選手のクラブIDをnullにする
+   * @param id 選手ID
+   */
+  @Update("UPDATE players SET club_id = null WHERE id = #{id}")
+  void updatePlayerClubIdNull(int id);
 }

--- a/src/main/java/football/StatsManagement/service/FootballService.java
+++ b/src/main/java/football/StatsManagement/service/FootballService.java
@@ -443,6 +443,21 @@ public class FootballService {
     repository.updateClubLeague(id, leagueId);
   }
 
+  /**
+   * 選手のクラブIDをnullに更新
+   * @param id 選手ID
+   * @throws ResourceConflictException 元々clubIdがnullの場合
+   */
+  @Transactional
+  public void updatePlayerClubIdNull(int id) throws ResourceNotFoundException, ResourceConflictException {
+    Player player = getPlayer(id);
+    // 元々clubIdがnullの場合はResourceConflictExceptionを投げる
+    if (player.getClubId() == null) {
+      throw new ResourceConflictException("Player is already free");
+    }
+    repository.updatePlayerClubIdNull(id);
+  }
+
 //  other
 
   /**

--- a/src/test/java/football/StatsManagement/FootballIntegrationTest.java
+++ b/src/test/java/football/StatsManagement/FootballIntegrationTest.java
@@ -556,7 +556,7 @@ class FootballIntegrationTest {
         }
         """;
 
-    Player expected = new Player(47, 1, "PlayerAAAC", 3);
+    Player expected = new Player(48, 1, "PlayerAAAC", 3);
     String expectedJson = objectMapper.writeValueAsString(expected);
 
     mockMvc.perform(MockMvcRequestBuilders.post("/player")

--- a/src/test/java/football/StatsManagement/FootballIntegrationTest.java
+++ b/src/test/java/football/StatsManagement/FootballIntegrationTest.java
@@ -1,9 +1,8 @@
 package football.StatsManagement;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
@@ -706,7 +705,7 @@ class FootballIntegrationTest {
       "2020-08-01,  4, 9, 10,  1, 1, 1, 0,  true, 29,  2, 1, 2, 0,  true, 24, 'Home club and player are not matched'",
       "2020-08-01,  4, 9,  2,  1, 1, 1, 0,  true, 29,  2, 1, 2, 0,  true, 24, 'Away club is not in the league'",
       "2020-08-01,  4, 1,  2,  1, 1, 1, 0,  true, 29,  2, 1, 2, 0,  true, 24, 'Home club is not in the league'",
-//      "2020-08-01, 99, 1,  2,  1, 1, 1, 0,  true, 29,  2, 1, 2, 0,  true, 24, 'League not found'",  ※ResouceNotFoundExceptionが発生するため、個別対応
+//      "2020-08-01, 99, 1,  2,  1, 1, 1, 0,  true, 29,  2, 1, 2, 0,  true, 24, 'League not found'",  ※ResourceNotFoundExceptionが発生するため、個別対応
       "2019-08-01, 99, 1,  2,  1, 1, 1, 0,  true, 29,  2, 1, 2, 0,  true, 24, 'Game date must be in the current season period'"
   })
   @DisplayName("試合結果の登録_サービス内で例外処理を発生させるパターン")
@@ -760,7 +759,7 @@ class FootballIntegrationTest {
         .andExpect(status().isBadRequest())
         .andExpect(result -> {
           Exception resolvedException = result.getResolvedException();
-          assertTrue(resolvedException instanceof FootballException);
+          assertInstanceOf(FootballException.class, resolvedException);
           assertEquals(expectedMessage, resolvedException.getMessage());
         });
   }
@@ -821,7 +820,7 @@ class FootballIntegrationTest {
         .andExpect(status().isNotFound())
         .andExpect(result -> {
           Exception resolvedException = result.getResolvedException();
-          assertTrue(resolvedException instanceof ResourceNotFoundException);
+          assertInstanceOf(ResourceNotFoundException.class, resolvedException);
           assertEquals(expectedMessage, resolvedException.getMessage());
         });
   }
@@ -881,7 +880,7 @@ class FootballIntegrationTest {
         .andExpect(status().isBadRequest())
         .andExpect(result -> {
           Exception resolvedException = result.getResolvedException();
-          assertTrue(resolvedException instanceof FootballException);
+          assertInstanceOf(FootballException.class, resolvedException);
           assertEquals(errorMessage, resolvedException.getMessage());
         });
   }
@@ -931,7 +930,7 @@ class FootballIntegrationTest {
         .andExpect(status().isBadRequest())
         .andExpect(result -> {
           Exception resolvedException = result.getResolvedException();
-          assertTrue(resolvedException instanceof FootballException);
+          assertInstanceOf(FootballException.class, resolvedException);
           assertEquals(expectedMessage, resolvedException.getMessage());
         });
   }
@@ -955,7 +954,7 @@ class FootballIntegrationTest {
         .andExpect(status().isConflict())
         .andExpect(result -> {
           Exception resolvedException = result.getResolvedException();
-          assertTrue(resolvedException instanceof ResourceConflictException);
+          assertInstanceOf(ResourceConflictException.class, resolvedException);
           assertEquals(expectedMessage, resolvedException.getMessage());
         });
   }
@@ -1000,7 +999,7 @@ class FootballIntegrationTest {
         .andExpect(status().isConflict())
         .andExpect(result -> {
           Exception resolvedException = result.getResolvedException();
-          assertTrue(resolvedException instanceof ResourceConflictException);
+          assertInstanceOf(ResourceConflictException.class, resolvedException);
           assertEquals(expectedMessage, resolvedException.getMessage());
         });
   }
@@ -1024,7 +1023,7 @@ class FootballIntegrationTest {
         .andExpect(status().isBadRequest())
         .andExpect(result -> {
           Exception resolvedException = result.getResolvedException();
-          assertTrue(resolvedException instanceof FootballException);
+          assertInstanceOf(FootballException.class, resolvedException);
           assertEquals(expectedMessage, resolvedException.getMessage());
         });
   }
@@ -1057,7 +1056,36 @@ class FootballIntegrationTest {
         .andExpect(status().isConflict())
         .andExpect(result -> {
           Exception resolvedException = result.getResolvedException();
-          assertTrue(resolvedException instanceof ResourceConflictException);
+          assertInstanceOf(ResourceConflictException.class, resolvedException);
+          assertEquals(expectedMessage, resolvedException.getMessage());
+        });
+  }
+
+  @Test
+  @DisplayName("選手を無所属状態にできること")
+  void makePlayerFree() throws Exception {
+    int playerId = 1;
+
+    Player expected = new Player(playerId, null, "PlayerAAAA", 1);
+    String expectedJson = objectMapper.writeValueAsString(expected);
+
+    mockMvc.perform(MockMvcRequestBuilders.patch("/player-make-free/" + playerId))
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+  }
+
+  @Test
+  @DisplayName("選手を無所属状態にする_既に無所属の場合はResourceConflictExceptionが発生すること")
+  void makePlayerFreeWithNoClub() throws Exception {
+    int playerId = 47;
+
+    String expectedMessage = "Player is already free";
+
+    mockMvc.perform(MockMvcRequestBuilders.patch("/player-make-free/" + playerId))
+        .andExpect(status().isConflict())
+        .andExpect(result -> {
+          Exception resolvedException = result.getResolvedException();
+          assertInstanceOf(ResourceConflictException.class, resolvedException);
           assertEquals(expectedMessage, resolvedException.getMessage());
         });
   }

--- a/src/test/java/football/StatsManagement/controller/FootballControllerTest.java
+++ b/src/test/java/football/StatsManagement/controller/FootballControllerTest.java
@@ -1065,6 +1065,25 @@ class FootballControllerTest {
             result.getResolvedException()));
   }
 
+  @Test
+  @DisplayName("選手を無所属状態ににすることができること")
+  void makePlayerFree() throws Exception {
+    int playerId = 1;
+    mockMvc.perform(MockMvcRequestBuilders.patch("/player-make-free/" + playerId))
+        .andExpect(status().isOk());
+    verify(footballService, times(1)).updatePlayerClubIdNull(playerId);
+  }
+
+  @Test
+  @DisplayName("選手を無所属状態にする際にパスバリアブルのバリデーションエラーが発生すること")
+  void makePlayerFreeWithInvalidPathVariable() throws Exception {
+    int playerId = 0;
+    mockMvc.perform(MockMvcRequestBuilders.patch("/player-make-free/" + playerId))
+        .andExpect(status().isBadRequest())
+        .andExpect(result -> assertInstanceOf(ConstraintViolationException.class,
+            result.getResolvedException()));
+  }
+
 
   // 複数のフィールドのバリデーションエラーを検証するためのヘルパーメソッド
   private void assertMethodArgumentNotValidExceptions(

--- a/src/test/java/football/StatsManagement/repository/FootballRepositoryTest.java
+++ b/src/test/java/football/StatsManagement/repository/FootballRepositoryTest.java
@@ -518,7 +518,8 @@ class FootballRepositoryTest {
         new Player(43, 10, "PlayerBBDL", 12),
         new Player(44, 10, "PlayerBBDM", 13),
         new Player(45, 10, "PlayerBBDN", 14),
-        new Player(46, 10, "PlayerBBDO", 15)
+        new Player(46, 10, "PlayerBBDO", 15),
+        new Player(47, null, "PlayerNoClub", 1)
     );
   }
 
@@ -765,9 +766,6 @@ class FootballRepositoryTest {
     String name = "UpdatedPlayer";
 
     // Arrange
-    Player player = sut.selectPlayer(id).orElseGet(() -> mock(Player.class));
-    player.setNumber(number);
-    player.setName(name);
     Player expected = new Player(id, 1, name, number);
 
     // Act
@@ -786,9 +784,6 @@ class FootballRepositoryTest {
     int number = 99;
 
     // Arrange
-    Player player = sut.selectPlayer(id).orElseGet(() -> mock(Player.class));
-    player.setClubId(clubId);
-    player.setNumber(number);
     Player expected = new Player(id, clubId, "PlayerAAAA", number);
 
     // Act
@@ -806,13 +801,27 @@ class FootballRepositoryTest {
     int leagueId = 2;
 
     // Arrange
-    Club club = sut.selectClub(id).orElseGet(() -> mock(Club.class));
-    club.setLeagueId(leagueId);
     Club expected = new Club(id, leagueId, "ClubAAA");
 
     // Act
     sut.updateClubLeague(id, leagueId);
     Club actual = sut.selectClub(id).orElseGet(() -> mock(Club.class));
+
+    // Assert
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  @DisplayName("選手のクラブIDをnullに更新できること_更新後の情報が適切であること")
+  void updatePlayerClubIdNull() {
+    int id = 1;
+
+    // Arrange
+    Player expected = new Player(id, null, "PlayerAAAA", 1);
+
+    // Act
+    sut.updatePlayerClubIdNull(id);
+    Player actual = sut.selectPlayer(id).orElseGet(() -> mock(Player.class));
 
     // Assert
     assertEquals(expected, actual);

--- a/src/test/java/football/StatsManagement/service/FootballServiceTest.java
+++ b/src/test/java/football/StatsManagement/service/FootballServiceTest.java
@@ -599,6 +599,32 @@ class FootballServiceTest {
         ResourceConflictException.class, () -> sut.updateClubLeague(1, 1));
   }
 
+  @Test
+  @DisplayName("選手のクラブIDのnull更新_リポジトリが適切に処理されること")
+  void updatePlayerNClubIdNull() throws ResourceNotFoundException, ResourceConflictException {
+    int id = 1;
+
+    // Arrange
+    when(repository.selectPlayer(id)).thenReturn(Optional.of(new Player(id, 1, "sampleName", 1)));
+
+    // Act
+    sut.updatePlayerClubIdNull(id);
+
+    // Assert
+    verify(repository, times(1)).updatePlayerClubIdNull(id);
+  }
+
+  @Test
+  @DisplayName("選手のクラブIDのnull更新_クラブIDがnullの場合に適切に例外処理されること")
+  void updatePlayerClubIdNull_withNullClubId() {
+    int id = 1;
+
+    // Arrange
+    when(repository.selectPlayer(id)).thenReturn(Optional.of(new Player(id, null, "sampleName", 1)));
+    // Act & Assert
+    assertThrows(ResourceConflictException.class, () -> sut.updatePlayerClubIdNull(id));
+  }
+
   @ParameterizedTest
   @CsvSource({
       "2024-08-01, 1, 2, 2, 1, 1   , 1, 2, '○2-1'",

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -68,7 +68,9 @@ INSERT INTO players (name, club_id, number) VALUES
   ('PlayerBBDL', 10, 12),
   ('PlayerBBDM', 10, 13),
   ('PlayerBBDN', 10, 14),
-  ('PlayerBBDO', 10, 15);
+  ('PlayerBBDO', 10, 15),
+--  無所属選手を追加
+  ('PlayerNoClub', null, 1);
 
 
 INSERT INTO seasons (id, name, start_date, end_date, current) VALUES


### PR DESCRIPTION
PlayerのclubIdをnullとすることで、無所属状態を表す

付随する変更
・PlayerのclubIdをint→Integerに変更

その他の変更
・EntityクラスからValidationアノテーションを削除